### PR TITLE
Update moment-recur.js - fixing IE9/10 toString.call() bug

### DIFF
--- a/moment-recur.js
+++ b/moment-recur.js
@@ -289,7 +289,7 @@
         function unitsToObject(units) {
             var list = {};
             
-            if ( toString.call(units) == '[object Array]' ) {
+            if ( Object.prototype.toString.call(units) == '[object Array]' ) {
                 units.forEach(function(v) {
                     list[v] = true;
                 });
@@ -297,7 +297,7 @@
             else if ( units === Object(units) ) {
                 list = units;
             }
-            else if ( (toString.call(units) == '[object Number]') || (toString.call(units) == '[object String]') ) {
+            else if ( (Object.prototype.toString.call(units) == '[object Number]') || (Object.prototype.toString.call(units) == '[object String]') ) {
                 list[units] = true;
             }
             else {


### PR DESCRIPTION
changed the toString.call(units) calls in unitsToObject() function - lines 292 & 300 to Object.prototype.toString.call(units) because IE9 & IE10 were throwing "SCRIPT65535: Invalid calling object" errors. Tested in IE9/10 FF 27.0.1 & Chrome 33.0.1750.154 m
