### PR TITLE
Remove moment deprecation warning

### DIFF
--- a/moment-recur.js
+++ b/moment-recur.js
@@ -695,10 +695,9 @@
         if (this.tz && typeof(moment.tz) == 'function' ) {
             return moment.tz(this.format('YYYY/MM/DD'), 'UTC');
         } else {
-            return this.hours(0).minutes(0).seconds(0).milliseconds(0).add('minute',this.utcOffset()).utcOffset(0);
+            return this.hours(0).minutes(0).seconds(0).milliseconds(0).add(this.utcOffset(), "minute").utcOffset(0);
         }
     };
-
 
     return moment;
 }));


### PR DESCRIPTION
`moment().add(period, number) is deprecated. Please use moment().add(number, period)`