### PR TITLE
Remove global flag on install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "gulp test",
-    "preinstall": "npm install bower gulp -g",
+    "preinstall": "npm install bower gulp",
     "postinstall": "bower install"
   }
 }


### PR DESCRIPTION
There is no need to install packages globally, `npm` exposes local modules when running using `npm run`.