### PR TITLE
dateOnly() parse format

### DIFF
--- a/moment-recur.js
+++ b/moment-recur.js
@@ -740,7 +740,7 @@
     // Plugin for removing all time information from a given date
     moment.fn.dateOnly = function() {
         if (this.tz && typeof(moment.tz) == 'function' ) {
-            return moment.tz(this.format('YYYY/MM/DD'), 'UTC');
+            return moment.tz(this.format('YYYY-MM-DD'), 'UTC');
         } else {
             return this.hours(0).minutes(0).seconds(0).milliseconds(0).add(this.utcOffset(), "minute").utcOffset(0);
         }


### PR DESCRIPTION
Produces deprecation warning.

Changed dateOnly() date format to prevent moment construction falling back to js Date.
See: https://github.com/moment/moment/issues/1407

Example code:

    var moment = require('moment-timezone');
    require('moment-recur');
    var b = moment("2014-01-01").dateOnly();
    console.log(b);