### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "moment-recur",
   "main": "moment-recur.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/c-trimm/moment-recur",
   "authors": [
     "Casey Trimm <me@caseytrimm.com>"


### PR DESCRIPTION
Update version number to match latest tagged release. This fixes the following warning when installing the library via Bower.
 
`bower mismatch      Version declared in the json (1.0.4) is different than the resolved one (1.0.5)`